### PR TITLE
External id for mapping in OCL should be set from the uuid of the Con…

### DIFF
--- a/omrs/management/commands/extract_db.py
+++ b/omrs/management/commands/extract_db.py
@@ -572,7 +572,7 @@ class Command(BaseCommand):
                     map_type=ref_map.map_type.name,
                     from_concept=concept,
                     to_concept_code=ref_map.concept_reference_term.code,
-                    external_id=ref_map.concept_reference_term.uuid)
+                    external_id=ref_map.uuid)
                 self.cnt_internal_mappings_exported += 1
 
             # External Mapping


### PR DESCRIPTION
…ceptMap, not the uuid of the ReferenceTerm